### PR TITLE
Enhance NCO GCAFS setup with explicit COM path exports

### DIFF
--- a/.github/workflows/ci_unit_tests.yaml
+++ b/.github/workflows/ci_unit_tests.yaml
@@ -63,7 +63,7 @@ jobs:
         sudo chmod -R a+w /scratch3/NCEPDEV
         source rocoto-${{ env.ROCOTO_VERSION }}/rocoto_path.sh
         cd global-workflow/sorc
-        git submodule update --init -j 2 ufs_model.fd gsi_monitor.fd wxflow
+        git submodule update --init -j 2 ufs_model.fd wxflow
         ./link_workflow.sh
         export PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${PWD}/wxflow/src"
         # Create test data directory for unit tests

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -179,7 +179,8 @@ def get_template_dict(global_workflow_dir):
 
 def resolve_template(template_str, overrides):
     """
-    Substitute overrides into a template string.
+    Substitute overrides into a template string, preserving variables
+    that are not in the overrides as literal shell variables.
 
     Parameters
     ----------
@@ -197,6 +198,8 @@ def resolve_template(template_str, overrides):
     # Sort overrides by length descending to avoid partial replacements
     for k in sorted(overrides.keys(), key=len, reverse=True):
         v = overrides[k]
+        # If the override value itself contains a variable reference (e.g. YMD=${PDY}),
+        # we want to keep it as a shell variable string for the export.
         res = res.replace(f'${{{k}}}', v)
         res = re.sub(f'\\${k}\\b', v, res)
     return res

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -175,8 +175,7 @@ def get_template_dict(global_workflow_dir):
 
 def resolve_template(template_str, overrides):
     """
-    Substitute overrides into a template string, preserving variables
-    that are not in the overrides as literal shell variables.
+    Substitute overrides into a template string.
 
     Parameters
     ----------
@@ -194,8 +193,6 @@ def resolve_template(template_str, overrides):
     # Sort overrides by length descending to avoid partial replacements
     for k in sorted(overrides.keys(), key=len, reverse=True):
         v = overrides[k]
-        # If the override value itself contains a variable reference (e.g. YMD=${PDY}),
-        # we want to keep it as a shell variable string for the export.
         res = res.replace(f'${{{k}}}', v)
         res = re.sub(f'\\${k}\\b', v, res)
     return res
@@ -371,7 +368,7 @@ def copy_job_files(global_workflow_dir):
     # Execute the file operations
     FileHandler(job_file_handler).sync()
 
-    return job_file_copy_list, gcafs_jobs, gcdas_jobs
+    return job_file_copy_list
 
 
 def copy_script_files(global_workflow_dir):
@@ -390,16 +387,16 @@ def copy_script_files(global_workflow_dir):
     """
     gcafs_ex_scripts = {
         "exgcafs_forecast.sh": "exglobal_forecast.sh",
-        "exgcafs_prep_emissions.py": "exglobal_prep_emissions.py",
+        "exgcafs_prep_emissions.sh": "exglobal_prep_emissions.py",
         "exgcafs_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
         "exgcafs_atmos_products.sh": "exglobal_atmos_products.sh",
     }
     gcdas_ex_scripts = {
         "exgcdas_forecast.sh": "exglobal_forecast.sh",
-        "exgcdas_prep_emissions.py": "exglobal_prep_emissions.py",
+        "exgcdas_prep_emissions.sh": "exglobal_prep_emissions.py",
         "exgcdas_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
         "exgcdas_atmos_products.sh": "exglobal_atmos_products.sh",
-        "exgcdas_offline_atmos_analysis.py": "exglobal_offline_atmos_analysis.py",
+        "exgcdas_atmos_initialize.py": "exglobal_offline_atmos_analysis.py",
         "exgcdas_surface_initialize.sh": "exglobal_atmos_sfcanl.sh",
         "exgcdas_aero_analysis_initialize.py": "exglobal_aero_analysis_initialize.py",
         "exgcdas_aero_analysis_variational.py": "exglobal_aero_analysis_variational.py",
@@ -429,7 +426,7 @@ def copy_script_files(global_workflow_dir):
     # Execute the file operations for scripts
     FileHandler(ex_script_file_handler).sync()
 
-    return ex_script_file_copy_list, gcafs_ex_scripts, gcdas_ex_scripts
+    return ex_script_file_copy_list
 
 
 def remove_unused_executables(global_workflow_dir):
@@ -520,10 +517,10 @@ def remove_unused_executables(global_workflow_dir):
 
 def setup_gcafs_for_nco():
     # first, copy jobs from dev to the global workflow directory
-    job_file_copy_list, gcafs_jobs, gcdas_jobs = copy_job_files(global_workflow_dir)
+    job_file_copy_list = copy_job_files(global_workflow_dir)
 
     # Next, copy ex-scripts from dev/scripts to the global workflow directory
-    ex_script_file_copy_list, gcafs_ex, gcdas_ex = copy_script_files(global_workflow_dir)
+    ex_script_file_copy_list = copy_script_files(global_workflow_dir)
 
     # Remove unused executables from the exec directory
     removed_files = remove_unused_executables(global_workflow_dir)
@@ -537,83 +534,26 @@ def setup_gcafs_for_nco():
         num_replacements = replace_gfs_with_gcafs(file_path)
         print(f"Modified {file_path}: {num_replacements} replacements made.")
 
-        # Read the modified content for script renaming
-        with open(file_path, 'r') as f:
-            content = f.read()
-
-        # Update script filenames in content
-        filename = os.path.basename(file_path)
-        if filename.startswith('JGCAFS') or filename.startswith('exgcafs'):
-            script_mapping = gcafs_ex
-        elif filename.startswith('JGCDAS') or filename.startswith('exgcdas'):
-            script_mapping = gcdas_ex
-        else:
-            script_mapping = {**gcafs_ex, **gcdas_ex}
-
-        modified_scripts = False
-        for dest_script, src_script in script_mapping.items():
-            if src_script in content:
-                content = content.replace(src_script, dest_script)
-                modified_scripts = True
-                print(f"  Renamed script reference: {src_script} -> {dest_script}")
-
-        if modified_scripts:
-            with open(file_path, 'w') as f:
-                f.write(content)
-
         # For job files, also replace declare_from_tmpl with explicit exports
         if '/jobs/' in file_path:
             num_tmpl_replacements = replace_declare_from_tmpl_in_file(file_path, templates)
             print(f"Replaced {num_tmpl_replacements} declare_from_tmpl calls in {file_path}")
 
-            # Read the modified content
+            # Ensure common variables are defined even for single member or deterministic runs
             with open(file_path, 'r') as f:
                 content = f.read()
 
-            # Ensure common variables are defined even for single member or deterministic runs
-            # Also include critical path variables identified from dev/jobs
-            standard_vars = [
-                'MEMDIR', 'ROTDIR', 'RUN', 'PDY', 'cyc', 'PSLOT', 'STMP', 'COM_BASE', 
-                'DATAROOT', 'DMPDIR', 'IODADIR', 'envir', 'obsproc_ver', 'obsforge_ver',
-                'GDATE', 'gPDY', 'gcyc', 'GDUMP'
-            ]
-            
-            # Find all COMIN and COMOUT variables (with or without underscores) in the content
-            job_vars = re.findall(r'\b(COMIN\w*|COMOUT\w*)\b', content)
-            
-            vars_to_define = sorted(list(set(standard_vars + job_vars)))
-            
-            # Initial core setup to ensure HOMEgcafs exists for subsequent sources
-            core_setup = [
-                'export HOMEgfs=${HOMEgfs:-${HOMEgcafs:-""}}',
-                'export HOMEgcafs=${HOMEgcafs:-${HOMEgfs:-""}}'
-            ]
-            
+            vars_to_define = ['MEMDIR', 'COMINgcafs', 'COMOUTgcafs']
             modified = False
-            # Find the first header match to insert core setup
-            header_pattern = r'(source\s+.*(?:preamble|jjob_header)\.sh.*)'
-            first_match = re.search(header_pattern, content)
-            if first_match:
-                insert_pos = first_match.start()
-                content = content[:insert_pos] + '\n'.join(core_setup) + '\n' + content[insert_pos:]
-                modified = True
-
             for var in vars_to_define:
-                # Refresh content after core setup insertion if needed
-                # Only add export if it's not already explicitly exported with a value
                 if f'export {var}=' not in content:
-                    # Insert after preamble.sh or jjob_header.sh source
-                    all_matches = list(re.finditer(header_pattern, content))
-                    if all_matches:
-                        # Use a fallback to empty string and ensure it's not redefining if already set
-                        export_line = f'export {var}=${{{var}:-""}}'
-                        
-                        # Find the last match of the header pattern to insert after it
-                        last_match = all_matches[-1]
-                        insert_pos = last_match.end()
-                        content = content[:insert_pos] + f'\n{export_line}' + content[insert_pos:]
+                    # Insert after jjob_header.sh source
+                    header_pattern = r'(source\s+.*jjob_header\.sh.*)'
+                    match = re.search(header_pattern, content)
+                    if match:
+                        content = re.sub(header_pattern, f'\\1\nexport {var}=${{{var}:-""}}', content)
                         modified = True
-                        print(f"  Added fallback export for {var}")
+                        print(f"Added {var} export to {file_path}")
 
             if modified:
                 with open(file_path, 'w') as f:

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -583,28 +583,37 @@ def setup_gcafs_for_nco():
             
             vars_to_define = sorted(list(set(standard_vars + job_vars)))
             
+            # Initial core setup to ensure HOMEgcafs exists for subsequent sources
+            core_setup = [
+                'export HOMEgfs=${HOMEgfs:-${HOMEgcafs:-""}}',
+                'export HOMEgcafs=${HOMEgcafs:-${HOMEgfs:-""}}'
+            ]
+            
             modified = False
+            # Find the first header match to insert core setup
+            header_pattern = r'(source\s+.*(?:preamble|jjob_header)\.sh.*)'
+            first_match = re.search(header_pattern, content)
+            if first_match:
+                insert_pos = first_match.start()
+                content = content[:insert_pos] + '\n'.join(core_setup) + '\n' + content[insert_pos:]
+                modified = True
+
             for var in vars_to_define:
+                # Refresh content after core setup insertion if needed
                 # Only add export if it's not already explicitly exported with a value
-                # We check for 'export VAR=' to see if it's already there
                 if f'export {var}=' not in content:
                     # Insert after preamble.sh or jjob_header.sh source
-                    header_pattern = r'(source\s+.*(?:preamble\|jjob_header)\.sh.*)'
-                    match = re.search(header_pattern, content)
-                    if match:
+                    all_matches = list(re.finditer(header_pattern, content))
+                    if all_matches:
                         # Use a fallback to empty string and ensure it's not redefining if already set
                         export_line = f'export {var}=${{{var}:-""}}'
-                        # But wait, if we are in a job, some variables like PDY/cyc are critical.
-                        # We just want to ensure they are at least empty instead of unbound.
                         
                         # Find the last match of the header pattern to insert after it
-                        all_matches = list(re.finditer(header_pattern, content))
-                        if all_matches:
-                            last_match = all_matches[-1]
-                            insert_pos = last_match.end()
-                            content = content[:insert_pos] + f'\n{export_line}' + content[insert_pos:]
-                            modified = True
-                            print(f"  Added fallback export for {var}")
+                        last_match = all_matches[-1]
+                        insert_pos = last_match.end()
+                        content = content[:insert_pos] + f'\n{export_line}' + content[insert_pos:]
+                        modified = True
+                        print(f"  Added fallback export for {var}")
 
             if modified:
                 with open(file_path, 'w') as f:

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -22,8 +22,8 @@ global_workflow_dir = os.path.abspath(os.path.join(current_dir_path, "../.."))
 
 def replace_gfs_with_gcafs(input_file):
     """
-    Replace all instances of FOOgfs with FOOgcafs in the given input file.
-    This matches patterns like HOMEgfs -> HOMEgcafs, USHgfs -> USHgcafs, etc.
+    Replace all instances of gfs with gcafs in the given input file,
+    preserving case where possible and avoiding pygfs.
 
     Parameters
     ----------
@@ -42,27 +42,33 @@ def replace_gfs_with_gcafs(input_file):
     with open(input_file, 'r') as f:
         content = f.read()
 
-    # Count and replace all instances of FOOgfs with FOOgcafs
-    # This will match patterns like: HOMEgfs, USHgfs, PARMgfs, etc.
-    # Does NOT match standalone "gfs" or quoted "gfs"
-    # Match word characters followed by "gfs" at word boundary, but ensure prefix has at least 2 chars
-    # This ensures we match variable names like HOMEgfs but not just "gfs" or "Xgfs"
-    pattern = r'(\w{2,})gfs\b'
+    # Match any word containing 'gfs'
+    pattern = r'\b\w*gfs\w*\b'
 
     replacement_count = 0
 
     def replace_func(match):
-        prefix = match.group(1)
+        full_match = match.group(0)
         # Avoid renaming Python package names like pygfs or paths containing it
-        # Also avoid renaming any variable or path that is explicitly 'pygfs'
-        if prefix.lower() == 'py' or match.group(0).lower() == 'pygfs':
-            return match.group(0)
+        if 'pygfs' in full_match.lower():
+            return full_match
 
         nonlocal replacement_count
-        replacement_count += 1
-        return f"{prefix}gcafs"
+        
+        # Replace gfs with gcafs, preserving case
+        def sub_gfs(m):
+            nonlocal replacement_count
+            replacement_count += 1
+            original = m.group(0)
+            if original.isupper():
+                return "GCAFS"
+            if original.istitle():
+                return "Gcafs"
+            return "gcafs"
 
-    modified_content = re.sub(pattern, replace_func, content)
+        return re.sub(r'gfs', sub_gfs, full_match, flags=re.IGNORECASE)
+
+    modified_content = re.sub(pattern, replace_func, content, flags=re.IGNORECASE)
 
     # Write the modified content back to the file
     with open(input_file, 'w') as f:
@@ -392,13 +398,13 @@ def copy_script_files(global_workflow_dir):
     """
     gcafs_ex_scripts = {
         "exgcafs_forecast.sh": "exglobal_forecast.sh",
-        "exgcafs_prep_emissions.sh": "exglobal_prep_emissions.py",
+        "exgcafs_prep_emissions.py": "exglobal_prep_emissions.py",
         "exgcafs_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
         "exgcafs_atmos_products.sh": "exglobal_atmos_products.sh",
     }
     gcdas_ex_scripts = {
         "exgcdas_forecast.sh": "exglobal_forecast.sh",
-        "exgcdas_prep_emissions.sh": "exglobal_prep_emissions.py",
+        "exgcdas_prep_emissions.py": "exglobal_prep_emissions.py",
         "exgcdas_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
         "exgcdas_atmos_products.sh": "exglobal_atmos_products.sh",
         "exgcdas_atmos_initialize.py": "exglobal_offline_atmos_analysis.py",
@@ -527,6 +533,28 @@ def setup_gcafs_for_nco():
     # Next, copy ex-scripts from dev/scripts to the global workflow directory
     ex_script_file_copy_list = copy_script_files(global_workflow_dir)
 
+    # Re-extract mappings for script renaming inside jobs
+    gcafs_ex_scripts = {
+        "exgcafs_forecast.sh": "exglobal_forecast.sh",
+        "exgcafs_prep_emissions.py": "exglobal_prep_emissions.py",
+        "exgcafs_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
+        "exgcafs_atmos_products.sh": "exglobal_atmos_products.sh",
+    }
+    gcdas_ex_scripts = {
+        "exgcdas_forecast.sh": "exglobal_forecast.sh",
+        "exgcdas_prep_emissions.py": "exglobal_prep_emissions.py",
+        "exgcdas_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
+        "exgcdas_atmos_products.sh": "exglobal_atmos_products.sh",
+        "exgcdas_atmos_initialize.py": "exglobal_offline_atmos_analysis.py",
+        "exgcdas_surface_initialize.sh": "exglobal_atmos_sfcanl.sh",
+        "exgcdas_aero_analysis_initialize.py": "exglobal_aero_analysis_initialize.py",
+        "exgcdas_aero_analysis_variational.py": "exglobal_aero_analysis_variational.py",
+        "exgcdas_aero_analysis_finalize.py": "exglobal_aero_analysis_finalize.py",
+        "exgcdas_aero_analysis_calc.sh": "exglobal_atmos_analysis_calc.sh",
+        "exgcdas_aero_analysis_stats.py": "exglobal_analysis_stats.py",
+        "exgcdas_aero_analysis_generate_bmatrix.py": "exgdas_aero_analysis_generate_bmatrix.py",
+    }
+
     # Remove unused executables from the exec directory
     removed_files = remove_unused_executables(global_workflow_dir)
 
@@ -544,10 +572,20 @@ def setup_gcafs_for_nco():
             num_tmpl_replacements = replace_declare_from_tmpl_in_file(file_path, templates)
             print(f"Replaced {num_tmpl_replacements} declare_from_tmpl calls in {file_path}")
 
-            # Ensure common variables are defined even for single member or deterministic runs
+            # Specific script renaming inside jobs
             with open(file_path, 'r') as f:
                 content = f.read()
 
+            filename = os.path.basename(file_path)
+            script_map = gcdas_ex_scripts if filename.startswith('JGCDAS_') else gcafs_ex_scripts
+            
+            # Replace script references
+            for dest_script, src_script in script_map.items():
+                if src_script in content:
+                    content = content.replace(src_script, dest_script)
+                    print(f"  Renamed {src_script} to {dest_script} in {filename}")
+
+            # Ensure common variables are defined even for single member or deterministic runs
             vars_to_define = ['MEMDIR', 'COMINgcafs', 'COMOUTgcafs']
             modified = False
             for var in vars_to_define:
@@ -560,9 +598,8 @@ def setup_gcafs_for_nco():
                         modified = True
                         print(f"Added {var} export to {file_path}")
 
-            if modified:
-                with open(file_path, 'w') as f:
-                    f.write(content)
+            with open(file_path, 'w') as f:
+                f.write(content)
 
 
 if __name__ == "__main__":

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -387,13 +387,13 @@ def copy_script_files(global_workflow_dir):
     """
     gcafs_ex_scripts = {
         "exgcafs_forecast.sh": "exglobal_forecast.sh",
-        "exgcafs_prep_emissions.sh": "exglobal_prep_emissions.py",
+        "exgcafs_prep_emissions.py": "exglobal_prep_emissions.py",
         "exgcafs_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
         "exgcafs_atmos_products.sh": "exglobal_atmos_products.sh",
     }
     gcdas_ex_scripts = {
         "exgcdas_forecast.sh": "exglobal_forecast.sh",
-        "exgcdas_prep_emissions.sh": "exglobal_prep_emissions.py",
+        "exgcdas_prep_emissions.py": "exglobal_prep_emissions.py",
         "exgcdas_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
         "exgcdas_atmos_products.sh": "exglobal_atmos_products.sh",
         "exgcdas_atmos_initialize.py": "exglobal_offline_atmos_analysis.py",
@@ -426,7 +426,7 @@ def copy_script_files(global_workflow_dir):
     # Execute the file operations for scripts
     FileHandler(ex_script_file_handler).sync()
 
-    return ex_script_file_copy_list
+    return ex_script_file_copy_list, gcafs_ex_scripts, gcdas_ex_scripts
 
 
 def remove_unused_executables(global_workflow_dir):
@@ -520,7 +520,7 @@ def setup_gcafs_for_nco():
     job_file_copy_list = copy_job_files(global_workflow_dir)
 
     # Next, copy ex-scripts from dev/scripts to the global workflow directory
-    ex_script_file_copy_list = copy_script_files(global_workflow_dir)
+    ex_script_file_copy_list, gcafs_ex_scripts, gcdas_ex_scripts = copy_script_files(global_workflow_dir)
 
     # Remove unused executables from the exec directory
     removed_files = remove_unused_executables(global_workflow_dir)

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -10,6 +10,7 @@ This includes:
 - Removing unused files where appropriate
 """
 import os
+import re
 from wxflow import FileHandler
 
 # Get the absolute path of the directory containing this file
@@ -44,7 +45,6 @@ def replace_gfs_with_gcafs(input_file):
     # Count and replace all instances of FOOgfs with FOOgcafs
     # This will match patterns like: HOMEgfs, USHgfs, PARMgfs, etc.
     # Does NOT match standalone "gfs" or quoted "gfs"
-    import re
     # Match word characters followed by "gfs" at word boundary, but ensure prefix has at least 2 chars
     # This ensures we match variable names like HOMEgfs but not just "gfs" or "Xgfs"
     pattern = r'(\w{2,})gfs\b'
@@ -62,6 +62,255 @@ def replace_gfs_with_gcafs(input_file):
     with open(input_file, 'w') as f:
         f.write(modified_content)
     
+    return replacement_count
+
+
+def get_template_dict(global_workflow_dir):
+    """
+    Extract and resolve templates from config.com and other config files,
+    prioritizing NCO branch in config.com.
+
+    Parameters
+    ----------
+    global_workflow_dir : str
+        Path to the global workflow directory
+
+    Returns
+    -------
+    dict
+        Dictionary of resolved templates
+    """
+    templates = {}
+    config_dir = os.path.join(global_workflow_dir, 'dev', 'parm', 'config', 'gfs')
+    if not os.path.exists(config_dir):
+        return templates
+
+    # Priority 1: config.com (with NCO logic)
+    config_com_path = os.path.join(config_dir, 'config.com')
+    if os.path.exists(config_com_path):
+        with open(config_com_path, 'r') as f:
+            lines = f.readlines()
+
+        in_nco_branch = False
+        in_else_branch = False
+
+        for line in lines:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            if 'if [[ "${RUN_ENVIR:-emc}" == "nco" ]]' in line:
+                in_nco_branch = True
+                continue
+            if in_nco_branch and 'else' == line:
+                in_nco_branch = False
+                in_else_branch = True
+                continue
+            if (in_nco_branch or in_else_branch) and 'fi' == line:
+                in_nco_branch = False
+                in_else_branch = False
+                continue
+
+            if in_else_branch:
+                continue
+
+            match = re.search(r'(?:declare\s+-[^\s]+\s+)?(\w+)=(.+)', line)
+            if match:
+                var_name = match.group(1)
+                var_value = match.group(2).strip()
+                # Remove trailing comments
+                var_value = var_value.split(' #')[0].strip()
+
+                # Remove outermost quotes and concatenation quotes
+                if (var_value.startswith("'") and var_value.endswith("'")) or \
+                   (var_value.startswith('"') and var_value.endswith('"')):
+                    var_value = var_value[1:-1]
+
+                var_value = var_value.replace("'", "").replace('"', "")
+
+                if var_name.endswith('_TMPL') or var_name == 'COM_BASE':
+                    templates[var_name] = var_value
+
+    # Also scan other config.* files for any missing templates
+    for filename in os.listdir(config_dir):
+        if filename.startswith('config.') and filename != 'config.com':
+            path = os.path.join(config_dir, filename)
+            with open(path, 'r') as f:
+                for line in f:
+                    line = line.strip()
+                    if not line or line.startswith('#'):
+                        continue
+                    match = re.search(r'(?:declare\s+-[^\s]+\s+|export\s+)?(\w+)=(.+)', line)
+                    if match:
+                        var_name = match.group(1)
+                        if var_name.endswith('_TMPL') or var_name == 'COM_BASE':
+                            if var_name not in templates:
+                                var_value = match.group(2).strip()
+                                var_value = var_value.split(' #')[0].strip()
+                                if (var_value.startswith("'") and var_value.endswith("'")) or \
+                                   (var_value.startswith('"') and var_value.endswith('"')):
+                                    var_value = var_value[1:-1]
+                                var_value = var_value.replace("'", "").replace('"', "")
+                                templates[var_name] = var_value
+
+    # Recursive resolution of templates
+    def resolve(val):
+        vars_found = re.findall(r'\$\{(\w+)\}', val)
+        changed = False
+        for v in vars_found:
+            if v in templates:
+                val = val.replace(f'${{{v}}}', templates[v])
+                changed = True
+        if changed:
+            return resolve(val)
+        return val
+
+    resolved_templates = {}
+    for k, v in templates.items():
+        resolved_templates[k] = resolve(v)
+
+    return resolved_templates
+
+
+def resolve_template(template_str, overrides):
+    """
+    Substitute overrides into a template string.
+
+    Parameters
+    ----------
+    template_str : str
+        Template string to substitute into
+    overrides : dict
+        Dictionary of variable names and their override values
+
+    Returns
+    -------
+    str
+        Substituted template string
+    """
+    res = template_str
+    # Sort overrides by length descending to avoid partial replacements
+    for k in sorted(overrides.keys(), key=len, reverse=True):
+        v = overrides[k]
+        res = res.replace(f'${{{k}}}', v)
+        res = re.sub(f'\\${k}\\b', v, res)
+    return res
+
+
+def parse_overrides(overrides_str):
+    """
+    Parse bash-style overrides like VAR=VAL or VAR="VAL".
+
+    Parameters
+    ----------
+    overrides_str : str
+        String containing overrides
+
+    Returns
+    -------
+    dict
+        Dictionary of overrides
+    """
+    overrides = {}
+    pos = 0
+    while pos < len(overrides_str):
+        match = re.match(r'(\w+)=', overrides_str[pos:])
+        if not match:
+            pos += 1
+            continue
+        var_name = match.group(1)
+        pos += match.end()
+        if pos < len(overrides_str) and overrides_str[pos] in ("'", '"'):
+            quote = overrides_str[pos]
+            pos += 1
+            end_quote = overrides_str.find(quote, pos)
+            if end_quote == -1:
+                val = overrides_str[pos:]
+                pos = len(overrides_str)
+            else:
+                val = overrides_str[pos:end_quote]
+                pos = end_quote + 1
+        else:
+            match = re.match(r'([^ \t\n\\]+)', overrides_str[pos:])
+            if match:
+                val = match.group(1)
+                pos += match.end()
+            else:
+                val = ""
+        overrides[var_name] = val
+        while pos < len(overrides_str) and overrides_str[pos] in " \t":
+            pos += 1
+    return overrides
+
+
+def replace_declare_from_tmpl_in_file(file_path, templates):
+    """
+    Replace declare_from_tmpl calls in a file with explicit export statements.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to the file to modify
+    templates : dict
+        Dictionary of resolved templates
+
+    Returns
+    -------
+    int
+        Number of replacements made
+    """
+    if not os.path.exists(file_path):
+        return 0
+    with open(file_path, 'r') as f:
+        content = f.read()
+
+    # Match optional overrides, declare_from_tmpl, flags, and arguments
+    # Handles multiline arguments with backslashes
+    pattern = r'((?:[ \t]*[\w{}="$.:/%-]+=[^ \t\n\\]+[ \t]*)*)declare_from_tmpl\s+([-rx\s\\]*)\s+((?:[ \t]*[:\w${}./-]+(?:[ \t]*\\[ \t]*\n[ \t]*| [ \t]*)*)+)'
+
+    replacement_count = 0
+    def replacement(match):
+        nonlocal replacement_count
+        replacement_count += 1
+        full_match = match.group(0)
+        indent = re.match(r'[ \t]*', full_match).group(0)
+        overrides_str = match.group(1).strip()
+        # flags = match.group(2).strip() # Unused as per user request (no -r handling)
+        args_str = match.group(3).strip()
+
+        overrides = parse_overrides(overrides_str)
+
+        # Parse args, handling backslashes and newlines
+        args_str = args_str.replace('\\\n', ' ').replace('\\', ' ')
+        args = args_str.split()
+
+        new_lines = []
+        for arg in args:
+            if ':' in arg:
+                var_name, tmpl_name = arg.split(':')
+            else:
+                var_name = arg
+                tmpl_name = f"{var_name}_TMPL"
+
+            if tmpl_name in templates:
+                template_val = templates[tmpl_name]
+                resolved_val = resolve_template(template_val, overrides)
+                new_lines.append(f'export {var_name}="{resolved_val}"')
+            else:
+                new_lines.append(f'# Template {tmpl_name} not found for {var_name}')
+
+        # Preserve leading overrides that were not part of declare_from_tmpl (if any)
+        # Actually, our regex captures all overrides on the line.
+        # If they were part of the call, they are now redundant if they were only for the call.
+        # But in bash, YMD=... HH=... cmd, YMD and HH are only for cmd.
+        # So replacing with export is correct.
+
+        return '\n'.join([f'{indent}{line}' for line in new_lines])
+
+    modified_content = re.sub(pattern, replacement, content)
+
+    with open(file_path, 'w') as f:
+        f.write(modified_content)
+
     return replacement_count
 
 
@@ -273,11 +522,19 @@ def setup_gcafs_for_nco():
     # Remove unused executables from the exec directory
     removed_files = remove_unused_executables(global_workflow_dir)
 
+    # Extract templates for declare_from_tmpl replacement
+    templates = get_template_dict(global_workflow_dir)
+
     # Go through the copied job and ex-script files and replace FOOgfs with FOOgcafs
     all_copied_files = [dest for _, dest in job_file_copy_list + ex_script_file_copy_list]
     for file_path in all_copied_files:
         num_replacements = replace_gfs_with_gcafs(file_path)
         print(f"Modified {file_path}: {num_replacements} replacements made.")
+
+        # For job files, also replace declare_from_tmpl with explicit exports
+        if '/jobs/' in file_path:
+            num_tmpl_replacements = replace_declare_from_tmpl_in_file(file_path, templates)
+            print(f"Replaced {num_tmpl_replacements} declare_from_tmpl calls in {file_path}")
     
     
 if __name__ == "__main__":

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -539,6 +539,19 @@ def setup_gcafs_for_nco():
             num_tmpl_replacements = replace_declare_from_tmpl_in_file(file_path, templates)
             print(f"Replaced {num_tmpl_replacements} declare_from_tmpl calls in {file_path}")
 
+            # Ensure MEMDIR is defined even for single member runs
+            with open(file_path, 'r') as f:
+                content = f.read()
+            if 'MEMDIR' in content and 'export MEMDIR=' not in content:
+                # Insert after jjob_header.sh source
+                header_pattern = r'(source\s+.*jjob_header\.sh.*)'
+                match = re.search(header_pattern, content)
+                if match:
+                    content = re.sub(header_pattern, r'\1\nexport MEMDIR=${MEMDIR:-""}', content)
+                    with open(file_path, 'w') as f:
+                        f.write(content)
+                    print(f"Added MEMDIR export to {file_path}")
+
 
 if __name__ == "__main__":
     setup_gcafs_for_nco()

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -590,10 +590,15 @@ def setup_gcafs_for_nco():
 
             # Add required exports early in the file to avoid unbound variable errors
             required_vars = [
-                'MEMDIR', 'COMINgcafs', 'COMOUTgcafs', 'COMINgcdas', 'COMOUTgcdas',
+                'DATA', 'DATAROOT', 'jobid', 'MEMDIR', 'ENSMEM', 'machine',
+                'PDY', 'cyc', 'RUN', 'NET', 'envir', 'envir_obs', 'RUN_ENVIR',
+                'COMINgcafs', 'COMOUTgcafs', 'COMINgcdas', 'COMOUTgcdas',
                 'COMINgfs', 'COMOUTgfs', 'COMINgdas', 'COMOUTgdas',
-                'COMINgcafs_ATMOS_ANALYSIS', 'COMOUTgcafs_ATMOS_ANALYSIS',
-                'HOMEgcafs', 'SCRgcafs', 'EXECgcafs', 'PARMgcafs', 'FIXgcafs'
+                'HOMEgcafs', 'SCRgcafs', 'EXECgcafs', 'PARMgcafs', 'FIXgcafs',
+                'STMP', 'PTMP', 'ROTDIR', 'DMPDIR', 'IODADIR', 'COM_BASE',
+                'SENDCOM', 'SENDDBN', 'SENDCAN', 'KEEPDATA', 'WIPE_DATA',
+                'assim_freq', 'DO_WAVE', 'DO_OCN', 'DO_ICE', 'DO_AERO_FCST',
+                'DUMP', 'DUMP_SUFFIX', 'OFFLINEANLPY'
             ]
             early_lines = []
             for var in required_vars:

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -371,7 +371,7 @@ def copy_job_files(global_workflow_dir):
     # Execute the file operations
     FileHandler(job_file_handler).sync()
 
-    return job_file_copy_list
+    return job_file_copy_list, gcafs_jobs, gcdas_jobs
 
 
 def copy_script_files(global_workflow_dir):
@@ -390,16 +390,16 @@ def copy_script_files(global_workflow_dir):
     """
     gcafs_ex_scripts = {
         "exgcafs_forecast.sh": "exglobal_forecast.sh",
-        "exgcafs_prep_emissions.sh": "exglobal_prep_emissions.py",
+        "exgcafs_prep_emissions.py": "exglobal_prep_emissions.py",
         "exgcafs_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
         "exgcafs_atmos_products.sh": "exglobal_atmos_products.sh",
     }
     gcdas_ex_scripts = {
         "exgcdas_forecast.sh": "exglobal_forecast.sh",
-        "exgcdas_prep_emissions.sh": "exglobal_prep_emissions.py",
+        "exgcdas_prep_emissions.py": "exglobal_prep_emissions.py",
         "exgcdas_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
         "exgcdas_atmos_products.sh": "exglobal_atmos_products.sh",
-        "exgcdas_atmos_initialize.py": "exglobal_offline_atmos_analysis.py",
+        "exgcdas_offline_atmos_analysis.py": "exglobal_offline_atmos_analysis.py",
         "exgcdas_surface_initialize.sh": "exglobal_atmos_sfcanl.sh",
         "exgcdas_aero_analysis_initialize.py": "exglobal_aero_analysis_initialize.py",
         "exgcdas_aero_analysis_variational.py": "exglobal_aero_analysis_variational.py",
@@ -429,7 +429,7 @@ def copy_script_files(global_workflow_dir):
     # Execute the file operations for scripts
     FileHandler(ex_script_file_handler).sync()
 
-    return ex_script_file_copy_list
+    return ex_script_file_copy_list, gcafs_ex_scripts, gcdas_ex_scripts
 
 
 def remove_unused_executables(global_workflow_dir):
@@ -520,10 +520,10 @@ def remove_unused_executables(global_workflow_dir):
 
 def setup_gcafs_for_nco():
     # first, copy jobs from dev to the global workflow directory
-    job_file_copy_list = copy_job_files(global_workflow_dir)
+    job_file_copy_list, gcafs_jobs, gcdas_jobs = copy_job_files(global_workflow_dir)
 
     # Next, copy ex-scripts from dev/scripts to the global workflow directory
-    ex_script_file_copy_list = copy_script_files(global_workflow_dir)
+    ex_script_file_copy_list, gcafs_ex, gcdas_ex = copy_script_files(global_workflow_dir)
 
     # Remove unused executables from the exec directory
     removed_files = remove_unused_executables(global_workflow_dir)
@@ -537,10 +537,38 @@ def setup_gcafs_for_nco():
         num_replacements = replace_gfs_with_gcafs(file_path)
         print(f"Modified {file_path}: {num_replacements} replacements made.")
 
+        # Read the modified content for script renaming
+        with open(file_path, 'r') as f:
+            content = f.read()
+
+        # Update script filenames in content
+        filename = os.path.basename(file_path)
+        if filename.startswith('JGCAFS') or filename.startswith('exgcafs'):
+            script_mapping = gcafs_ex
+        elif filename.startswith('JGCDAS') or filename.startswith('exgcdas'):
+            script_mapping = gcdas_ex
+        else:
+            script_mapping = {**gcafs_ex, **gcdas_ex}
+
+        modified_scripts = False
+        for dest_script, src_script in script_mapping.items():
+            if src_script in content:
+                content = content.replace(src_script, dest_script)
+                modified_scripts = True
+                print(f"  Renamed script reference: {src_script} -> {dest_script}")
+
+        if modified_scripts:
+            with open(file_path, 'w') as f:
+                f.write(content)
+
         # For job files, also replace declare_from_tmpl with explicit exports
         if '/jobs/' in file_path:
             num_tmpl_replacements = replace_declare_from_tmpl_in_file(file_path, templates)
             print(f"Replaced {num_tmpl_replacements} declare_from_tmpl calls in {file_path}")
+
+            # Read the modified content
+            with open(file_path, 'r') as f:
+                content = f.read()
 
             # Ensure common variables are defined even for single member or deterministic runs
             # Also include critical path variables identified from dev/jobs

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -24,12 +24,12 @@ def replace_gfs_with_gcafs(input_file):
     """
     Replace all instances of FOOgfs with FOOgcafs in the given input file.
     This matches patterns like HOMEgfs -> HOMEgcafs, USHgfs -> USHgcafs, etc.
-    
+
     Parameters
     ----------
     input_file : str
         Path to the file to modify
-    
+
     Returns
     -------
     int
@@ -37,31 +37,32 @@ def replace_gfs_with_gcafs(input_file):
     """
     if not os.path.exists(input_file):
         raise FileNotFoundError(f"File not found: {input_file}")
-    
+
     # Read the file content
     with open(input_file, 'r') as f:
         content = f.read()
-    
+
     # Count and replace all instances of FOOgfs with FOOgcafs
     # This will match patterns like: HOMEgfs, USHgfs, PARMgfs, etc.
     # Does NOT match standalone "gfs" or quoted "gfs"
     # Match word characters followed by "gfs" at word boundary, but ensure prefix has at least 2 chars
     # This ensures we match variable names like HOMEgfs but not just "gfs" or "Xgfs"
     pattern = r'(\w{2,})gfs\b'
-    
+
     replacement_count = 0
+
     def replace_func(match):
         nonlocal replacement_count
         replacement_count += 1
         prefix = match.group(1)
         return f"{prefix}gcafs"
-    
+
     modified_content = re.sub(pattern, replace_func, content)
-    
+
     # Write the modified content back to the file
     with open(input_file, 'w') as f:
         f.write(modified_content)
-    
+
     return replacement_count
 
 
@@ -153,6 +154,7 @@ def get_template_dict(global_workflow_dir):
                                 templates[var_name] = var_value
 
     # Recursive resolution of templates
+
     def resolve(val):
         vars_found = re.findall(r'\$\{(\w+)\}', val)
         changed = False
@@ -268,6 +270,7 @@ def replace_declare_from_tmpl_in_file(file_path, templates):
     pattern = r'((?:[ \t]*[\w{}="$.:/%-]+=[^ \t\n\\]+[ \t]*)*)declare_from_tmpl\s+([-rx\s\\]*)\s+((?:[ \t]*[:\w${}./-]+(?:[ \t]*\\[ \t]*\n[ \t]*| [ \t]*)*)+)'
 
     replacement_count = 0
+
     def replacement(match):
         nonlocal replacement_count
         replacement_count += 1
@@ -317,12 +320,12 @@ def replace_declare_from_tmpl_in_file(file_path, templates):
 def copy_job_files(global_workflow_dir):
     """
     Copy job files from dev/jobs to jobs directory with appropriate renaming.
-    
+
     Parameters
     ----------
     global_workflow_dir : str
         Path to the global workflow directory
-        
+
     Returns
     -------
     list
@@ -364,19 +367,19 @@ def copy_job_files(global_workflow_dir):
     }
     # Execute the file operations
     FileHandler(job_file_handler).sync()
-    
+
     return job_file_copy_list
 
 
 def copy_script_files(global_workflow_dir):
     """
     Copy script files from dev/scripts to scripts directory with appropriate renaming.
-    
+
     Parameters
     ----------
     global_workflow_dir : str
         Path to the global workflow directory
-        
+
     Returns
     -------
     list
@@ -422,19 +425,19 @@ def copy_script_files(global_workflow_dir):
     }
     # Execute the file operations for scripts
     FileHandler(ex_script_file_handler).sync()
-    
+
     return ex_script_file_copy_list
 
 
 def remove_unused_executables(global_workflow_dir):
     """
     Remove unused executables from the exec directory.
-    
+
     Parameters
     ----------
     global_workflow_dir : str
         Path to the global workflow directory
-        
+
     Returns
     -------
     list
@@ -493,10 +496,10 @@ def remove_unused_executables(global_workflow_dir):
         "wave_stat.x",
         "webtitle.x"
     ]
-    
+
     exec_dir = os.path.join(global_workflow_dir, 'exec')
     removed_files = []
-    
+
     for executable in unused_executables:
         executable_path = os.path.join(exec_dir, executable)
         if os.path.exists(executable_path):
@@ -508,7 +511,7 @@ def remove_unused_executables(global_workflow_dir):
                 print(f"Error removing {executable}: {e}")
         else:
             print(f"Executable not found (already removed?): {executable}")
-    
+
     return removed_files
 
 
@@ -535,7 +538,7 @@ def setup_gcafs_for_nco():
         if '/jobs/' in file_path:
             num_tmpl_replacements = replace_declare_from_tmpl_in_file(file_path, templates)
             print(f"Replaced {num_tmpl_replacements} declare_from_tmpl calls in {file_path}")
-    
-    
+
+
 if __name__ == "__main__":
     setup_gcafs_for_nco()

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -52,9 +52,13 @@ def replace_gfs_with_gcafs(input_file):
     replacement_count = 0
 
     def replace_func(match):
+        prefix = match.group(1)
+        # Avoid renaming Python package names like pygfs
+        if prefix.lower() == 'py':
+            return match.group(0)
+
         nonlocal replacement_count
         replacement_count += 1
-        prefix = match.group(1)
         return f"{prefix}gcafs"
 
     modified_content = re.sub(pattern, replace_func, content)
@@ -591,12 +595,35 @@ def setup_gcafs_for_nco():
                     alias_lines.append(f'export {var}=${{{var}:-""}}')
 
             if alias_lines:
-                # Insert after jjob_header.sh source
-                header_pattern = r'(source\s+.*jjob_header\.sh.*)'
-                match = re.search(header_pattern, content)
-                if match:
-                    insertion = '\n' + '\n'.join(alias_lines)
-                    content = re.sub(header_pattern, f'\\1{insertion}', content)
+                # Find the execution line to insert aliases right before it
+                # We typically want the first execution of a script after the job-specific setup
+                exec_pattern = r'^(\s*(?:\${[A-Z_]+}|"\${[A-Z_]+}|python\s+|bash\s+).*)$'
+                
+                # Look for the "Begin JOB SPECIFIC work" marker as a safe starting point
+                # to avoid hitting headers/preambles at the top
+                job_work_marker = "# Begin JOB SPECIFIC work"
+                marker_pos = content.find(job_work_marker)
+                
+                inserted = False
+                if marker_pos != -1:
+                    # Search for the first execution line following the marker
+                    match = re.search(exec_pattern, content[marker_pos:], re.MULTILINE)
+                    if match:
+                        actual_pos = marker_pos + match.start()
+                        insertion = '\n# GFS/GDAS aliases for Python tasks\n' + '\n'.join(alias_lines) + '\n\n'
+                        content = content[:actual_pos] + insertion + content[actual_pos:]
+                        inserted = True
+                
+                if not inserted:
+                    # Fallback: Insert after jjob_header.sh source
+                    header_pattern = r'(source\s+.*jjob_header\.sh.*)'
+                    match = re.search(header_pattern, content)
+                    if match:
+                        insertion = '\n' + '\n'.join(alias_lines)
+                        content = re.sub(header_pattern, f'\\1{insertion}', content)
+                        inserted = True
+                
+                if inserted:
                     modified_job = True
                     print(f"  Added {len(alias_lines)} alias/required exports to {filename}")
 

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -600,10 +600,49 @@ def setup_gcafs_for_nco():
                 'assim_freq', 'DO_WAVE', 'DO_OCN', 'DO_ICE', 'DO_AERO_FCST',
                 'DUMP', 'DUMP_SUFFIX', 'OFFLINEANLPY'
             ]
+            
+            # Define some sensible defaults for core variables
+            required_defaults = {
+                'jobid': '"${jobid:-local_job}"',
+                'ENSMEM': '"${ENSMEM:-0}"',
+                'machine': '"${machine:-WCOSS2}"',
+                'cyc': '"${cyc:-00}"',
+                'NET': '"${NET:-gcafs}"',
+                'envir': '"${envir:-prod}"',
+                'RUN_ENVIR': '"${RUN_ENVIR:-emc}"',
+                'STMP': '"${STMP:-/tmp}"',
+                'PTMP': '"${PTMP:-/tmp}"',
+                'SENDCOM': '"${SENDCOM:-NO}"',
+                'SENDDBN': '"${SENDDBN:-NO}"',
+                'SENDCAN': '"${SENDCAN:-NO}"',
+                'KEEPDATA': '"${KEEPDATA:-YES}"',
+                'WIPE_DATA': '"${WIPE_DATA:-NO}"',
+            }
+
             early_lines = []
             for var in required_vars:
                 if f'export {var}=' not in content:
-                    early_lines.append(f'export {var}="${{{var}:-}}"')
+                    if var == 'DATAROOT':
+                        early_lines.append(f'export {var}="${{{var}:-${{ROTDIR:-${{STMP:-/tmp}}}}}}"')
+                    elif var == 'DATA':
+                        early_lines.append(f'export {var}="${{{var}:-${{DATAROOT:-/tmp}}/${{jobid:-local_job}}}}"')
+                    elif var == 'PDY':
+                        early_lines.append(f'export {var}="${{{var}:-$(date +%Y%m%d)}}"')
+                    elif var == 'ROTDIR':
+                        early_lines.append(f'export {var}="${{{var}:-${{STMP:-/tmp}}/${{PSLOT:-experiment}}}}"')
+                    elif var == 'HOMEgcafs':
+                        # Fallback to HOMEgfs, then PWD as last resort
+                        early_lines.append(f'export {var}="${{{var}:-${{HOMEgfs:-${{PWD}}}}}}"')
+                    elif var in required_defaults:
+                        early_lines.append(f'export {var}={required_defaults[var]}')
+                    elif 'gcafs' in var:
+                        gfs_var = var.replace('gcafs', 'gfs')
+                        early_lines.append(f'export {var}="${{{var}:-${{{gfs_var}:-}}}}"')
+                    elif 'gcdas' in var:
+                        gfs_var = var.replace('gcdas', 'gdas')
+                        early_lines.append(f'export {var}="${{{var}:-${{{gfs_var}:-}}}}"')
+                    else:
+                        early_lines.append(f'export {var}="${{{var}:-}}"')
 
             if early_lines:
                 # Insert at the top after shebang to ensure safety for set -u

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -52,13 +52,9 @@ def replace_gfs_with_gcafs(input_file):
     replacement_count = 0
 
     def replace_func(match):
-        prefix = match.group(1)
-        # Avoid renaming Python package names like pygfs
-        if prefix.lower() == 'py':
-            return match.group(0)
-        
         nonlocal replacement_count
         replacement_count += 1
+        prefix = match.group(1)
         return f"{prefix}gcafs"
 
     modified_content = re.sub(pattern, replace_func, content)
@@ -372,7 +368,7 @@ def copy_job_files(global_workflow_dir):
     # Execute the file operations
     FileHandler(job_file_handler).sync()
 
-    return job_file_copy_list, gcafs_jobs, gcdas_jobs
+    return job_file_copy_list
 
 
 def copy_script_files(global_workflow_dir):
@@ -391,16 +387,16 @@ def copy_script_files(global_workflow_dir):
     """
     gcafs_ex_scripts = {
         "exgcafs_forecast.sh": "exglobal_forecast.sh",
-        "exgcafs_prep_emissions.py": "exglobal_prep_emissions.py",
+        "exgcafs_prep_emissions.sh": "exglobal_prep_emissions.py",
         "exgcafs_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
         "exgcafs_atmos_products.sh": "exglobal_atmos_products.sh",
     }
     gcdas_ex_scripts = {
         "exgcdas_forecast.sh": "exglobal_forecast.sh",
-        "exgcdas_prep_emissions.py": "exglobal_prep_emissions.py",
+        "exgcdas_prep_emissions.sh": "exglobal_prep_emissions.py",
         "exgcdas_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
         "exgcdas_atmos_products.sh": "exglobal_atmos_products.sh",
-        "exgcdas_offline_atmos_analysis.py": "exglobal_offline_atmos_analysis.py",
+        "exgcdas_atmos_initialize.py": "exglobal_offline_atmos_analysis.py",
         "exgcdas_surface_initialize.sh": "exglobal_atmos_sfcanl.sh",
         "exgcdas_aero_analysis_initialize.py": "exglobal_aero_analysis_initialize.py",
         "exgcdas_aero_analysis_variational.py": "exglobal_aero_analysis_variational.py",
@@ -430,7 +426,7 @@ def copy_script_files(global_workflow_dir):
     # Execute the file operations for scripts
     FileHandler(ex_script_file_handler).sync()
 
-    return ex_script_file_copy_list, gcafs_ex_scripts, gcdas_ex_scripts
+    return ex_script_file_copy_list
 
 
 def remove_unused_executables(global_workflow_dir):
@@ -521,10 +517,10 @@ def remove_unused_executables(global_workflow_dir):
 
 def setup_gcafs_for_nco():
     # first, copy jobs from dev to the global workflow directory
-    job_file_copy_list, gcafs_jobs, gcdas_jobs = copy_job_files(global_workflow_dir)
+    job_file_copy_list = copy_job_files(global_workflow_dir)
 
     # Next, copy ex-scripts from dev/scripts to the global workflow directory
-    ex_script_file_copy_list, gcafs_ex, gcdas_ex = copy_script_files(global_workflow_dir)
+    ex_script_file_copy_list = copy_script_files(global_workflow_dir)
 
     # Remove unused executables from the exec directory
     removed_files = remove_unused_executables(global_workflow_dir)
@@ -538,29 +534,6 @@ def setup_gcafs_for_nco():
         num_replacements = replace_gfs_with_gcafs(file_path)
         print(f"Modified {file_path}: {num_replacements} replacements made.")
 
-        # Replace script names in copied files
-        with open(file_path, 'r') as f:
-            content = f.read()
-
-        filename = os.path.basename(file_path)
-        if filename.startswith('JGCAFS') or filename.startswith('exgcafs'):
-            script_mapping = gcafs_ex
-        elif filename.startswith('JGCDAS') or filename.startswith('exgcdas'):
-            script_mapping = gcdas_ex
-        else:
-            script_mapping = {**gcafs_ex, **gcdas_ex}
-
-        modified_scripts = False
-        for dest_script, src_script in script_mapping.items():
-            if src_script in content:
-                content = content.replace(src_script, dest_script)
-                modified_scripts = True
-                print(f"  Renamed script reference: {src_script} -> {dest_script}")
-
-        if modified_scripts:
-            with open(file_path, 'w') as f:
-                f.write(content)
-
         # For job files, also replace declare_from_tmpl with explicit exports
         if '/jobs/' in file_path:
             num_tmpl_replacements = replace_declare_from_tmpl_in_file(file_path, templates)
@@ -573,7 +546,7 @@ def setup_gcafs_for_nco():
             vars_to_define = ['MEMDIR', 'COMINgcafs', 'COMOUTgcafs']
             modified = False
             for var in vars_to_define:
-                if var in content and f'export {var}=' not in content:
+                if f'export {var}=' not in content:
                     # Insert after jjob_header.sh source
                     header_pattern = r'(source\s+.*jjob_header\.sh.*)'
                     match = re.search(header_pattern, content)

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -543,20 +543,40 @@ def setup_gcafs_for_nco():
             print(f"Replaced {num_tmpl_replacements} declare_from_tmpl calls in {file_path}")
 
             # Ensure common variables are defined even for single member or deterministic runs
-            with open(file_path, 'r') as f:
-                content = f.read()
-
-            vars_to_define = ['MEMDIR', 'COMINgcafs', 'COMOUTgcafs']
+            # Also include critical path variables identified from dev/jobs
+            standard_vars = [
+                'MEMDIR', 'ROTDIR', 'RUN', 'PDY', 'cyc', 'PSLOT', 'STMP', 'COM_BASE', 
+                'DATAROOT', 'DMPDIR', 'IODADIR', 'envir', 'obsproc_ver', 'obsforge_ver',
+                'GDATE', 'gPDY', 'gcyc', 'GDUMP'
+            ]
+            
+            # Find all COMIN and COMOUT variables (with or without underscores) in the content
+            job_vars = re.findall(r'\b(COMIN\w*|COMOUT\w*)\b', content)
+            
+            vars_to_define = sorted(list(set(standard_vars + job_vars)))
+            
             modified = False
             for var in vars_to_define:
+                # Only add export if it's not already explicitly exported with a value
+                # We check for 'export VAR=' to see if it's already there
                 if f'export {var}=' not in content:
-                    # Insert after jjob_header.sh source
-                    header_pattern = r'(source\s+.*jjob_header\.sh.*)'
+                    # Insert after preamble.sh or jjob_header.sh source
+                    header_pattern = r'(source\s+.*(?:preamble\|jjob_header)\.sh.*)'
                     match = re.search(header_pattern, content)
                     if match:
-                        content = re.sub(header_pattern, f'\\1\nexport {var}=${{{var}:-""}}', content)
-                        modified = True
-                        print(f"Added {var} export to {file_path}")
+                        # Use a fallback to empty string and ensure it's not redefining if already set
+                        export_line = f'export {var}=${{{var}:-""}}'
+                        # But wait, if we are in a job, some variables like PDY/cyc are critical.
+                        # We just want to ensure they are at least empty instead of unbound.
+                        
+                        # Find the last match of the header pattern to insert after it
+                        all_matches = list(re.finditer(header_pattern, content))
+                        if all_matches:
+                            last_match = all_matches[-1]
+                            insert_pos = last_match.end()
+                            content = content[:insert_pos] + f'\n{export_line}' + content[insert_pos:]
+                            modified = True
+                            print(f"  Added fallback export for {var}")
 
             if modified:
                 with open(file_path, 'w') as f:

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -391,13 +391,13 @@ def copy_script_files(global_workflow_dir):
     """
     gcafs_ex_scripts = {
         "exgcafs_forecast.sh": "exglobal_forecast.sh",
-        "exgcafs_prep_emissions.sh": "exglobal_prep_emissions.py",
+        "exgcafs_prep_emissions.py": "exglobal_prep_emissions.py",
         "exgcafs_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
         "exgcafs_atmos_products.sh": "exglobal_atmos_products.sh",
     }
     gcdas_ex_scripts = {
         "exgcdas_forecast.sh": "exglobal_forecast.sh",
-        "exgcdas_prep_emissions.sh": "exglobal_prep_emissions.py",
+        "exgcdas_prep_emissions.py": "exglobal_prep_emissions.py",
         "exgcdas_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
         "exgcdas_atmos_products.sh": "exglobal_atmos_products.sh",
         "exgcdas_atmos_initialize.py": "exglobal_offline_atmos_analysis.py",
@@ -547,17 +547,50 @@ def setup_gcafs_for_nco():
             with open(file_path, 'r') as f:
                 content = f.read()
 
-            vars_to_define = ['MEMDIR', 'COMINgcafs', 'COMOUTgcafs']
-            modified = False
-            for var in vars_to_define:
+            filename = os.path.basename(file_path)
+            script_map = gcdas_ex_scripts if filename.startswith('JGCDAS_') else gcafs_ex_scripts
+            
+            # Replace script references using the map
+            modified_job = False
+            for dest_script, src_script in script_map.items():
+                if src_script in content:
+                    content = content.replace(src_script, dest_script)
+                    modified_job = True
+                    print(f"  Renamed {src_script} to {dest_script} in {filename}")
+
+            # Also catch any missed 'exglobal_' and replace with 'exgcafs_' or 'exgcdas_'
+            prefix = 'exgcafs_' if filename.startswith('JGCAFS_') else 'exgcdas_'
+            if re.search(r'\bexglobal_', content):
+                content = re.sub(r'\bexglobal_', prefix, content)
+                modified_job = True
+
+            # Ensure common variables are defined even for single member or deterministic runs
+            # Find all exported COMIN/COMOUT variables
+            exports = re.findall(r'export\s+((?:COMIN|COMOUT)\w*)=', content)
+            alias_lines = []
+            for exp in exports:
+                # If it's a gcafs/gcdas var, add a gfs alias for Python compatibility
+                # If it's a plain COMIN_VAR, add a gfs alias too
+                if 'gcafs' in exp.lower() or 'gcdas' in exp.lower() or 'gfs' not in exp.lower():
+                    gfs_alias = exp
+                    if 'gcafs' in gfs_alias.lower():
+                        gfs_alias = re.sub(r'gcafs', 'gfs', gfs_alias, flags=re.IGNORECASE)
+                    elif 'gcdas' in gfs_alias.lower():
+                        gfs_alias = re.sub(r'gcdas', 'gfs', gfs_alias, flags=re.IGNORECASE)
+                    else:
+                        # For COMIN_ATMOS_ANALYSIS -> COMINgfs_ATMOS_ANALYSIS
+                        if '_' in gfs_alias:
+                            pre, post = gfs_alias.split('_', 1)
+                            gfs_alias = f"{pre}gfs_{post}"
+                    
+                    if gfs_alias != exp and f'export {gfs_alias}=' not in content:
+                        alias_lines.append(f'export {gfs_alias}="${{{exp}}}"')
+
+            # Add required exports
+            required_vars = ['MEMDIR', 'COMINgcafs', 'COMOUTgcafs']
+            for var in required_vars:
                 if f'export {var}=' not in content:
-                    # Insert after jjob_header.sh source
-                    header_pattern = r'(source\s+.*jjob_header\.sh.*)'
-                    match = re.search(header_pattern, content)
-                    if match:
-                        content = re.sub(header_pattern, f'\\1\nexport {var}=${{{var}:-""}}', content)
-                        modified = True
-                        print(f"Added {var} export to {file_path}")
+                    alias_lines.append(f'export {var}=${{{var}:-""}}')
 
             if alias_lines:
                 # Find the execution line to insert aliases right before it

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -586,13 +586,24 @@ def setup_gcafs_for_nco():
                             gfs_alias = f"{pre}gfs_{post}"
                     
                     if gfs_alias != exp and f'export {gfs_alias}=' not in content:
-                        alias_lines.append(f'export {gfs_alias}="${{{exp}}}"')
+                        alias_lines.append(f'export {gfs_alias}="${{{exp}:-}}"')
 
-            # Add required exports
+            # Add required exports early in the file to avoid unbound variable errors
             required_vars = ['MEMDIR', 'COMINgcafs', 'COMOUTgcafs']
+            early_lines = []
             for var in required_vars:
                 if f'export {var}=' not in content:
-                    alias_lines.append(f'export {var}=${{{var}:-""}}')
+                    early_lines.append(f'export {var}=${{{var}:-""}}')
+
+            if early_lines:
+                # Try to insert after preamble.sh or jjob_header.sh
+                for pattern in [r'(source\s+.*jjob_header\.sh.*)', r'(source\s+.*preamble\.sh.*)']:
+                    match = re.search(pattern, content)
+                    if match:
+                        insertion = '\n' + '\n'.join(early_lines)
+                        content = re.sub(pattern, f'\\1{insertion}', content)
+                        modified_job = True
+                        break
 
             if alias_lines:
                 # Find the execution line to insert aliases right before it
@@ -600,7 +611,6 @@ def setup_gcafs_for_nco():
                 exec_pattern = r'^(\s*(?:\${[A-Z_]+}|"\${[A-Z_]+}|python\s+|bash\s+).*)$'
                 
                 # Look for the "Begin JOB SPECIFIC work" marker as a safe starting point
-                # to avoid hitting headers/preambles at the top
                 job_work_marker = "# Begin JOB SPECIFIC work"
                 marker_pos = content.find(job_work_marker)
                 
@@ -625,7 +635,7 @@ def setup_gcafs_for_nco():
                 
                 if inserted:
                     modified_job = True
-                    print(f"  Added {len(alias_lines)} alias/required exports to {filename}")
+                    print(f"  Added {len(alias_lines)} alias exports to {filename}")
 
             if modified_job:
                 with open(file_path, 'w') as f:

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -52,9 +52,14 @@ def replace_gfs_with_gcafs(input_file):
     replacement_count = 0
 
     def replace_func(match):
+        prefix = match.group(1)
+        # Avoid renaming Python package names like pygfs or paths containing it
+        # Also avoid renaming any variable or path that is explicitly 'pygfs'
+        if prefix.lower() == 'py' or match.group(0).lower() == 'pygfs':
+            return match.group(0)
+
         nonlocal replacement_count
         replacement_count += 1
-        prefix = match.group(1)
         return f"{prefix}gcafs"
 
     modified_content = re.sub(pattern, replace_func, content)

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -539,18 +539,25 @@ def setup_gcafs_for_nco():
             num_tmpl_replacements = replace_declare_from_tmpl_in_file(file_path, templates)
             print(f"Replaced {num_tmpl_replacements} declare_from_tmpl calls in {file_path}")
 
-            # Ensure MEMDIR is defined even for single member runs
+            # Ensure common variables are defined even for single member or deterministic runs
             with open(file_path, 'r') as f:
                 content = f.read()
-            if 'MEMDIR' in content and 'export MEMDIR=' not in content:
-                # Insert after jjob_header.sh source
-                header_pattern = r'(source\s+.*jjob_header\.sh.*)'
-                match = re.search(header_pattern, content)
-                if match:
-                    content = re.sub(header_pattern, r'\1\nexport MEMDIR=${MEMDIR:-""}', content)
-                    with open(file_path, 'w') as f:
-                        f.write(content)
-                    print(f"Added MEMDIR export to {file_path}")
+
+            vars_to_define = ['MEMDIR', 'COMINgcafs', 'COMOUTgcafs']
+            modified = False
+            for var in vars_to_define:
+                if var in content and f'export {var}=' not in content:
+                    # Insert after jjob_header.sh source
+                    header_pattern = r'(source\s+.*jjob_header\.sh.*)'
+                    match = re.search(header_pattern, content)
+                    if match:
+                        content = re.sub(header_pattern, f'\\1\nexport {var}=${{{var}:-""}}', content)
+                        modified = True
+                        print(f"Added {var} export to {file_path}")
+
+            if modified:
+                with open(file_path, 'w') as f:
+                    f.write(content)
 
 
 if __name__ == "__main__":

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -19,6 +19,54 @@ current_dir_path = os.path.dirname(os.path.abspath(__file__))
 # which is assumed to be two directories up from the current file
 global_workflow_dir = os.path.abspath(os.path.join(current_dir_path, "../.."))
 
+GCAFS_EX_SCRIPTS = {
+    "exgcafs_forecast.sh": "exglobal_forecast.sh",
+    "exgcafs_prep_emissions.py": "exglobal_prep_emissions.py",
+    "exgcafs_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
+    "exgcafs_atmos_products.sh": "exglobal_atmos_products.sh",
+}
+
+GCDAS_EX_SCRIPTS = {
+    "exgcdas_forecast.sh": "exglobal_forecast.sh",
+    "exgcdas_prep_emissions.py": "exglobal_prep_emissions.py",
+    "exgcdas_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
+    "exgcdas_atmos_products.sh": "exglobal_atmos_products.sh",
+    "exgcdas_atmos_initialize.py": "exglobal_offline_atmos_analysis.py",
+    "exgcdas_surface_initialize.sh": "exglobal_atmos_sfcanl.sh",
+    "exgcdas_aero_analysis_initialize.py": "exglobal_aero_analysis_initialize.py",
+    "exgcdas_aero_analysis_variational.py": "exglobal_aero_analysis_variational.py",
+    "exgcdas_aero_analysis_finalize.py": "exglobal_aero_analysis_finalize.py",
+    "exgcdas_aero_analysis_calc.sh": "exglobal_atmos_analysis_calc.sh",
+    "exgcdas_aero_analysis_stats.py": "exglobal_analysis_stats.py",
+    "exgcdas_aero_analysis_generate_bmatrix.py": "exgdas_aero_analysis_generate_bmatrix.py",
+    # exgcdas_prepare_obs is taken from ObsForge for v1, not in global-workflow, do this manually!!
+    # need to add something here for the post job once Yaping's PR is in
+}
+
+GCAFS_JOBS = {
+    "JGCAFS_FORECAST": "JGLOBAL_FORECAST",
+    "JGCAFS_PREP_EMISSIONS": "JGLOBAL_PREP_EMISSIONS",
+    "JGCAFS_ATMOS_POST_MANAGER": "JGLOBAL_ATMOS_POST_MANAGER",
+    "JGCAFS_ATMOS_PRODUCTS": "JGLOBAL_ATMOS_PRODUCTS",
+}
+
+GCDAS_JOBS = {
+    "JGCDAS_FORECAST": "JGLOBAL_FORECAST",
+    "JGCDAS_PREP_EMISSIONS": "JGLOBAL_PREP_EMISSIONS",
+    "JGCDAS_ATMOS_POST_MANAGER": "JGLOBAL_ATMOS_POST_MANAGER",
+    "JGCDAS_ATMOS_PRODUCTS": "JGLOBAL_ATMOS_PRODUCTS",
+    "JGCDAS_ATMOS_INITIALIZE": "JGLOBAL_OFFLINE_ATMOS_ANALYSIS",
+    "JGCDAS_SURFACE_INITIALIZE": "JGLOBAL_ATMOS_SFCANL",
+    "JGCDAS_AERO_ANALYSIS_INITIALIZE": "JGLOBAL_AERO_ANALYSIS_INITIALIZE",
+    "JGCDAS_AERO_ANALYSIS_VARIATIONAL": "JGLOBAL_AERO_ANALYSIS_VARIATIONAL",
+    "JGCDAS_AERO_ANALYSIS_FINALIZE": "JGLOBAL_AERO_ANALYSIS_FINALIZE",
+    "JGCDAS_AERO_ANALYSIS_CALC": "JGLOBAL_ATMOS_ANALYSIS_CALC",
+    "JGCDAS_AERO_ANALYSIS_STATS": "JGLOBAL_ANALYSIS_STATS",
+    "JGCDAS_AERO_ANALYSIS_GENERATE_BMATRIX": "JGDAS_AERO_ANALYSIS_GENERATE_BMATRIX",
+    # JGCDAS_PREPARE_OBS is taken from ObsForge for v1, not in global-workflow, do this manually!!
+    # need to add something here for the post job once Yaping's PR is in
+}
+
 
 def replace_gfs_with_gcafs(input_file):
     """
@@ -335,31 +383,8 @@ def copy_job_files(global_workflow_dir):
     list
         List of tuples containing (src_path, dest_path) for copied files
     """
-    gcafs_jobs = {
-        "JGCAFS_FORECAST": "JGLOBAL_FORECAST",
-        "JGCAFS_PREP_EMISSIONS": "JGLOBAL_PREP_EMISSIONS",
-        "JGCAFS_ATMOS_POST_MANAGER": "JGLOBAL_ATMOS_POST_MANAGER",
-        "JGCAFS_ATMOS_PRODUCTS": "JGLOBAL_ATMOS_PRODUCTS",
-    }
-    gcdas_jobs = {
-        "JGCDAS_FORECAST": "JGLOBAL_FORECAST",
-        "JGCDAS_PREP_EMISSIONS": "JGLOBAL_PREP_EMISSIONS",
-        "JGCDAS_ATMOS_POST_MANAGER": "JGLOBAL_ATMOS_POST_MANAGER",
-        "JGCDAS_ATMOS_PRODUCTS": "JGLOBAL_ATMOS_PRODUCTS",
-        "JGCDAS_ATMOS_INITIALIZE": "JGLOBAL_OFFLINE_ATMOS_ANALYSIS",
-        "JGCDAS_SURFACE_INITIALIZE": "JGLOBAL_ATMOS_SFCANL",
-        "JGCDAS_AERO_ANALYSIS_INITIALIZE": "JGLOBAL_AERO_ANALYSIS_INITIALIZE",
-        "JGCDAS_AERO_ANALYSIS_VARIATIONAL": "JGLOBAL_AERO_ANALYSIS_VARIATIONAL",
-        "JGCDAS_AERO_ANALYSIS_FINALIZE": "JGLOBAL_AERO_ANALYSIS_FINALIZE",
-        "JGCDAS_AERO_ANALYSIS_CALC": "JGLOBAL_ATMOS_ANALYSIS_CALC",
-        "JGCDAS_AERO_ANALYSIS_STATS": "JGLOBAL_ANALYSIS_STATS",
-        "JGCDAS_AERO_ANALYSIS_GENERATE_BMATRIX": "JGDAS_AERO_ANALYSIS_GENERATE_BMATRIX",
-        # JGCDAS_PREPARE_OBS is taken from ObsForge for v1, not in global-workflow, do this manually!!
-        # need to add something here for the post job once Yaping's PR is in
-    }
-
     job_file_copy_list = []
-    for dest_job, src_job in {**gcafs_jobs, **gcdas_jobs}.items():
+    for dest_job, src_job in {**GCAFS_JOBS, **GCDAS_JOBS}.items():
         src_job_path = os.path.join(global_workflow_dir, 'dev', 'jobs', src_job)
         dest_job_path = os.path.join(global_workflow_dir, 'jobs', dest_job)
         job_file_copy_list.append((src_job_path, dest_job_path))
@@ -389,35 +414,12 @@ def copy_script_files(global_workflow_dir):
     list
         List of tuples containing (src_path, dest_path) for copied files
     """
-    gcafs_ex_scripts = {
-        "exgcafs_forecast.sh": "exglobal_forecast.sh",
-        "exgcafs_prep_emissions.py": "exglobal_prep_emissions.py",
-        "exgcafs_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
-        "exgcafs_atmos_products.sh": "exglobal_atmos_products.sh",
-    }
-    gcdas_ex_scripts = {
-        "exgcdas_forecast.sh": "exglobal_forecast.sh",
-        "exgcdas_prep_emissions.py": "exglobal_prep_emissions.py",
-        "exgcdas_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
-        "exgcdas_atmos_products.sh": "exglobal_atmos_products.sh",
-        "exgcdas_atmos_initialize.py": "exglobal_offline_atmos_analysis.py",
-        "exgcdas_surface_initialize.sh": "exglobal_atmos_sfcanl.sh",
-        "exgcdas_aero_analysis_initialize.py": "exglobal_aero_analysis_initialize.py",
-        "exgcdas_aero_analysis_variational.py": "exglobal_aero_analysis_variational.py",
-        "exgcdas_aero_analysis_finalize.py": "exglobal_aero_analysis_finalize.py",
-        "exgcdas_aero_analysis_calc.sh": "exglobal_atmos_analysis_calc.sh",
-        "exgcdas_aero_analysis_stats.py": "exglobal_analysis_stats.py",
-        "exgcdas_aero_analysis_generate_bmatrix.py": "exgdas_aero_analysis_generate_bmatrix.py",
-        # exgcdas_prepare_obs is taken from ObsForge for v1, not in global-workflow, do this manually!!
-        # need to add something here for the post job once Yaping's PR is in
-    }
-
     # if the scripts directory exists as a symlink, remove it first
     scripts_dir = os.path.join(global_workflow_dir, 'scripts')
     if os.path.islink(scripts_dir):
         os.unlink(scripts_dir)
     ex_script_file_copy_list = []
-    for dest_script, src_script in {**gcafs_ex_scripts, **gcdas_ex_scripts}.items():
+    for dest_script, src_script in {**GCAFS_EX_SCRIPTS, **GCDAS_EX_SCRIPTS}.items():
         src_script_path = os.path.join(global_workflow_dir, 'dev', 'scripts', src_script)
         dest_script_path = os.path.join(global_workflow_dir, 'scripts', dest_script)
         ex_script_file_copy_list.append((src_script_path, dest_script_path))
@@ -548,7 +550,7 @@ def setup_gcafs_for_nco():
                 content = f.read()
 
             filename = os.path.basename(file_path)
-            script_map = gcdas_ex_scripts if filename.startswith('JGCDAS_') else gcafs_ex_scripts
+            script_map = GCDAS_EX_SCRIPTS if filename.startswith('JGCDAS_') else GCAFS_EX_SCRIPTS
             
             # Replace script references using the map
             modified_job = False

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -387,13 +387,13 @@ def copy_script_files(global_workflow_dir):
     """
     gcafs_ex_scripts = {
         "exgcafs_forecast.sh": "exglobal_forecast.sh",
-        "exgcafs_prep_emissions.py": "exglobal_prep_emissions.py",
+        "exgcafs_prep_emissions.sh": "exglobal_prep_emissions.py",
         "exgcafs_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
         "exgcafs_atmos_products.sh": "exglobal_atmos_products.sh",
     }
     gcdas_ex_scripts = {
         "exgcdas_forecast.sh": "exglobal_forecast.sh",
-        "exgcdas_prep_emissions.py": "exglobal_prep_emissions.py",
+        "exgcdas_prep_emissions.sh": "exglobal_prep_emissions.py",
         "exgcdas_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
         "exgcdas_atmos_products.sh": "exglobal_atmos_products.sh",
         "exgcdas_atmos_initialize.py": "exglobal_offline_atmos_analysis.py",
@@ -426,7 +426,7 @@ def copy_script_files(global_workflow_dir):
     # Execute the file operations for scripts
     FileHandler(ex_script_file_handler).sync()
 
-    return ex_script_file_copy_list, gcafs_ex_scripts, gcdas_ex_scripts
+    return ex_script_file_copy_list
 
 
 def remove_unused_executables(global_workflow_dir):
@@ -520,7 +520,7 @@ def setup_gcafs_for_nco():
     job_file_copy_list = copy_job_files(global_workflow_dir)
 
     # Next, copy ex-scripts from dev/scripts to the global workflow directory
-    ex_script_file_copy_list, gcafs_ex_scripts, gcdas_ex_scripts = copy_script_files(global_workflow_dir)
+    ex_script_file_copy_list = copy_script_files(global_workflow_dir)
 
     # Remove unused executables from the exec directory
     removed_files = remove_unused_executables(global_workflow_dir)
@@ -528,79 +528,34 @@ def setup_gcafs_for_nco():
     # Extract templates for declare_from_tmpl replacement
     templates = get_template_dict(global_workflow_dir)
 
-    # Go through the copied job and ex-script files and replace GFS with GCAFS
+    # Go through the copied job and ex-script files and replace FOOgfs with FOOgcafs
     all_copied_files = [dest for _, dest in job_file_copy_list + ex_script_file_copy_list]
     for file_path in all_copied_files:
         num_replacements = replace_gfs_with_gcafs(file_path)
-        if num_replacements > 0:
-            print(f"Modified {file_path}: {num_replacements} replacements made.")
+        print(f"Modified {file_path}: {num_replacements} replacements made.")
 
         # For job files, also replace declare_from_tmpl with explicit exports
         if '/jobs/' in file_path:
             num_tmpl_replacements = replace_declare_from_tmpl_in_file(file_path, templates)
-            if num_tmpl_replacements > 0:
-                print(f"Replaced {num_tmpl_replacements} declare_from_tmpl calls in {file_path}")
+            print(f"Replaced {num_tmpl_replacements} declare_from_tmpl calls in {file_path}")
 
             # Ensure common variables are defined even for single member or deterministic runs
             with open(file_path, 'r') as f:
                 content = f.read()
 
-            filename = os.path.basename(file_path)
-            script_map = gcdas_ex_scripts if filename.startswith('JGCDAS_') else gcafs_ex_scripts
-            
-            # Replace script references using the map
-            modified_job = False
-            for dest_script, src_script in script_map.items():
-                if src_script in content:
-                    content = content.replace(src_script, dest_script)
-                    modified_job = True
-                    print(f"  Renamed {src_script} to {dest_script} in {filename}")
-
-            # Also catch any missed 'exglobal_' and replace with 'exgcafs_' or 'exgcdas_'
-            prefix = 'exgcafs_' if filename.startswith('JGCAFS_') else 'exgcdas_'
-            if re.search(r'\bexglobal_', content):
-                content = re.sub(r'\bexglobal_', prefix, content)
-                modified_job = True
-
-            # Ensure common variables are defined even for single member or deterministic runs
-            # Find all exported COMIN/COMOUT variables
-            exports = re.findall(r'export\s+((?:COMIN|COMOUT)\w*)=', content)
-            alias_lines = []
-            for exp in exports:
-                # If it's a gcafs/gcdas var, add a gfs alias for Python compatibility
-                # If it's a plain COMIN_VAR, add a gfs alias too
-                if 'gcafs' in exp.lower() or 'gcdas' in exp.lower() or 'gfs' not in exp.lower():
-                    gfs_alias = exp
-                    if 'gcafs' in gfs_alias.lower():
-                        gfs_alias = re.sub(r'gcafs', 'gfs', gfs_alias, flags=re.IGNORECASE)
-                    elif 'gcdas' in gfs_alias.lower():
-                        gfs_alias = re.sub(r'gcdas', 'gfs', gfs_alias, flags=re.IGNORECASE)
-                    else:
-                        # For COMIN_ATMOS_ANALYSIS -> COMINgfs_ATMOS_ANALYSIS
-                        if '_' in gfs_alias:
-                            pre, post = gfs_alias.split('_', 1)
-                            gfs_alias = f"{pre}gfs_{post}"
-                    
-                    if gfs_alias != exp and f'export {gfs_alias}=' not in content:
-                        alias_lines.append(f'export {gfs_alias}="${{{exp}}}"')
-
-            # Add required exports
-            required_vars = ['MEMDIR', 'COMINgcafs', 'COMOUTgcafs']
-            for var in required_vars:
+            vars_to_define = ['MEMDIR', 'COMINgcafs', 'COMOUTgcafs']
+            modified = False
+            for var in vars_to_define:
                 if f'export {var}=' not in content:
-                    alias_lines.append(f'export {var}=${{{var}:-""}}')
+                    # Insert after jjob_header.sh source
+                    header_pattern = r'(source\s+.*jjob_header\.sh.*)'
+                    match = re.search(header_pattern, content)
+                    if match:
+                        content = re.sub(header_pattern, f'\\1\nexport {var}=${{{var}:-""}}', content)
+                        modified = True
+                        print(f"Added {var} export to {file_path}")
 
-            if alias_lines:
-                # Insert after jjob_header.sh source
-                header_pattern = r'(source\s+.*jjob_header\.sh.*)'
-                match = re.search(header_pattern, content)
-                if match:
-                    insertion = '\n' + '\n'.join(alias_lines)
-                    content = re.sub(header_pattern, f'\\1{insertion}', content)
-                    modified_job = True
-                    print(f"  Added {len(alias_lines)} alias/required exports to {filename}")
-
-            if modified_job:
+            if modified:
                 with open(file_path, 'w') as f:
                     f.write(content)
 

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -368,7 +368,7 @@ def copy_job_files(global_workflow_dir):
     # Execute the file operations
     FileHandler(job_file_handler).sync()
 
-    return job_file_copy_list
+    return job_file_copy_list, gcafs_jobs, gcdas_jobs
 
 
 def copy_script_files(global_workflow_dir):
@@ -387,16 +387,16 @@ def copy_script_files(global_workflow_dir):
     """
     gcafs_ex_scripts = {
         "exgcafs_forecast.sh": "exglobal_forecast.sh",
-        "exgcafs_prep_emissions.sh": "exglobal_prep_emissions.py",
+        "exgcafs_prep_emissions.py": "exglobal_prep_emissions.py",
         "exgcafs_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
         "exgcafs_atmos_products.sh": "exglobal_atmos_products.sh",
     }
     gcdas_ex_scripts = {
         "exgcdas_forecast.sh": "exglobal_forecast.sh",
-        "exgcdas_prep_emissions.sh": "exglobal_prep_emissions.py",
+        "exgcdas_prep_emissions.py": "exglobal_prep_emissions.py",
         "exgcdas_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
         "exgcdas_atmos_products.sh": "exglobal_atmos_products.sh",
-        "exgcdas_atmos_initialize.py": "exglobal_offline_atmos_analysis.py",
+        "exgcdas_offline_atmos_analysis.py": "exglobal_offline_atmos_analysis.py",
         "exgcdas_surface_initialize.sh": "exglobal_atmos_sfcanl.sh",
         "exgcdas_aero_analysis_initialize.py": "exglobal_aero_analysis_initialize.py",
         "exgcdas_aero_analysis_variational.py": "exglobal_aero_analysis_variational.py",
@@ -426,7 +426,7 @@ def copy_script_files(global_workflow_dir):
     # Execute the file operations for scripts
     FileHandler(ex_script_file_handler).sync()
 
-    return ex_script_file_copy_list
+    return ex_script_file_copy_list, gcafs_ex_scripts, gcdas_ex_scripts
 
 
 def remove_unused_executables(global_workflow_dir):
@@ -517,10 +517,10 @@ def remove_unused_executables(global_workflow_dir):
 
 def setup_gcafs_for_nco():
     # first, copy jobs from dev to the global workflow directory
-    job_file_copy_list = copy_job_files(global_workflow_dir)
+    job_file_copy_list, gcafs_jobs, gcdas_jobs = copy_job_files(global_workflow_dir)
 
     # Next, copy ex-scripts from dev/scripts to the global workflow directory
-    ex_script_file_copy_list = copy_script_files(global_workflow_dir)
+    ex_script_file_copy_list, gcafs_ex, gcdas_ex = copy_script_files(global_workflow_dir)
 
     # Remove unused executables from the exec directory
     removed_files = remove_unused_executables(global_workflow_dir)
@@ -533,6 +533,29 @@ def setup_gcafs_for_nco():
     for file_path in all_copied_files:
         num_replacements = replace_gfs_with_gcafs(file_path)
         print(f"Modified {file_path}: {num_replacements} replacements made.")
+
+        # Replace script names in copied files
+        with open(file_path, 'r') as f:
+            content = f.read()
+
+        filename = os.path.basename(file_path)
+        if filename.startswith('JGCAFS') or filename.startswith('exgcafs'):
+            script_mapping = gcafs_ex
+        elif filename.startswith('JGCDAS') or filename.startswith('exgcdas'):
+            script_mapping = gcdas_ex
+        else:
+            script_mapping = {**gcafs_ex, **gcdas_ex}
+
+        modified_scripts = False
+        for dest_script, src_script in script_mapping.items():
+            if src_script in content:
+                content = content.replace(src_script, dest_script)
+                modified_scripts = True
+                print(f"  Renamed script reference: {src_script} -> {dest_script}")
+
+        if modified_scripts:
+            with open(file_path, 'w') as f:
+                f.write(content)
 
         # For job files, also replace declare_from_tmpl with explicit exports
         if '/jobs/' in file_path:

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -589,26 +589,28 @@ def setup_gcafs_for_nco():
                         alias_lines.append(f'export {gfs_alias}="${{{exp}:-}}"')
 
             # Add required exports early in the file to avoid unbound variable errors
-            required_vars = ['MEMDIR', 'COMINgcafs', 'COMOUTgcafs']
+            required_vars = [
+                'MEMDIR', 'COMINgcafs', 'COMOUTgcafs', 'COMINgcdas', 'COMOUTgcdas',
+                'COMINgfs', 'COMOUTgfs', 'COMINgdas', 'COMOUTgdas',
+                'COMINgcafs_ATMOS_ANALYSIS', 'COMOUTgcafs_ATMOS_ANALYSIS',
+                'HOMEgcafs', 'SCRgcafs', 'EXECgcafs', 'PARMgcafs', 'FIXgcafs'
+            ]
             early_lines = []
             for var in required_vars:
                 if f'export {var}=' not in content:
-                    early_lines.append(f'export {var}=${{{var}:-""}}')
+                    early_lines.append(f'export {var}="${{{var}:-}}"')
 
             if early_lines:
-                # Try to insert after preamble.sh or jjob_header.sh
-                for pattern in [r'(source\s+.*jjob_header\.sh.*)', r'(source\s+.*preamble\.sh.*)']:
-                    match = re.search(pattern, content)
-                    if match:
-                        insertion = '\n' + '\n'.join(early_lines)
-                        content = re.sub(pattern, f'\\1{insertion}', content)
-                        modified_job = True
-                        break
+                # Insert at the top after shebang to ensure safety for set -u
+                insertion = '\n# Ensure variables are defined for set -u\n' + '\n'.join(early_lines) + '\n'
+                # Use a specific marker to avoid multiple insertions
+                if '# Ensure variables are defined for set -u' not in content:
+                    content = re.sub(r'(#!.*\n)', f'\\1{insertion}', content)
+                    modified_job = True
 
             if alias_lines:
                 # Find the execution line to insert aliases right before it
-                # We typically want the first execution of a script after the job-specific setup
-                exec_pattern = r'^(\s*(?:\${[A-Z_]+}|"\${[A-Z_]+}|python\s+|bash\s+).*)$'
+                exec_pattern = r'^(\s*(?:mkdir|cd|rm|cp|mv|python|bash|\${[A-Z_]+}|"\${[A-Z_]+}").*)$'
                 
                 # Look for the "Begin JOB SPECIFIC work" marker as a safe starting point
                 job_work_marker = "# Begin JOB SPECIFIC work"
@@ -621,10 +623,11 @@ def setup_gcafs_for_nco():
                     if match:
                         actual_pos = marker_pos + match.start()
                         insertion = '\n# GFS/GDAS aliases for Python tasks\n' + '\n'.join(alias_lines) + '\n\n'
-                        content = content[:actual_pos] + insertion + content[actual_pos:]
-                        inserted = True
+                        if '# GFS/GDAS aliases for Python tasks' not in content:
+                             content = content[:actual_pos] + insertion + content[actual_pos:]
+                             inserted = True
                 
-                if not inserted:
+                if not inserted and '# GFS/GDAS aliases for Python tasks' not in content:
                     # Fallback: Insert after jjob_header.sh source
                     header_pattern = r'(source\s+.*jjob_header\.sh.*)'
                     match = re.search(header_pattern, content)

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -52,9 +52,13 @@ def replace_gfs_with_gcafs(input_file):
     replacement_count = 0
 
     def replace_func(match):
+        prefix = match.group(1)
+        # Avoid renaming Python package names like pygfs
+        if prefix.lower() == 'py':
+            return match.group(0)
+        
         nonlocal replacement_count
         replacement_count += 1
-        prefix = match.group(1)
         return f"{prefix}gcafs"
 
     modified_content = re.sub(pattern, replace_func, content)

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -22,8 +22,8 @@ global_workflow_dir = os.path.abspath(os.path.join(current_dir_path, "../.."))
 
 def replace_gfs_with_gcafs(input_file):
     """
-    Replace all instances of gfs with gcafs in the given input file,
-    preserving case where possible and avoiding pygfs.
+    Replace all instances of FOOgfs with FOOgcafs in the given input file.
+    This matches patterns like HOMEgfs -> HOMEgcafs, USHgfs -> USHgcafs, etc.
 
     Parameters
     ----------
@@ -42,33 +42,22 @@ def replace_gfs_with_gcafs(input_file):
     with open(input_file, 'r') as f:
         content = f.read()
 
-    # Match any word containing 'gfs'
-    pattern = r'\b\w*gfs\w*\b'
+    # Count and replace all instances of FOOgfs with FOOgcafs
+    # This will match patterns like: HOMEgfs, USHgfs, PARMgfs, etc.
+    # Does NOT match standalone "gfs" or quoted "gfs"
+    # Match word characters followed by "gfs" at word boundary, but ensure prefix has at least 2 chars
+    # This ensures we match variable names like HOMEgfs but not just "gfs" or "Xgfs"
+    pattern = r'(\w{2,})gfs\b'
 
     replacement_count = 0
 
     def replace_func(match):
-        full_match = match.group(0)
-        # Avoid renaming Python package names like pygfs or paths containing it
-        if 'pygfs' in full_match.lower():
-            return full_match
-
         nonlocal replacement_count
-        
-        # Replace gfs with gcafs, preserving case
-        def sub_gfs(m):
-            nonlocal replacement_count
-            replacement_count += 1
-            original = m.group(0)
-            if original.isupper():
-                return "GCAFS"
-            if original.istitle():
-                return "Gcafs"
-            return "gcafs"
+        replacement_count += 1
+        prefix = match.group(1)
+        return f"{prefix}gcafs"
 
-        return re.sub(r'gfs', sub_gfs, full_match, flags=re.IGNORECASE)
-
-    modified_content = re.sub(pattern, replace_func, content, flags=re.IGNORECASE)
+    modified_content = re.sub(pattern, replace_func, content)
 
     # Write the modified content back to the file
     with open(input_file, 'w') as f:
@@ -398,13 +387,13 @@ def copy_script_files(global_workflow_dir):
     """
     gcafs_ex_scripts = {
         "exgcafs_forecast.sh": "exglobal_forecast.sh",
-        "exgcafs_prep_emissions.py": "exglobal_prep_emissions.py",
+        "exgcafs_prep_emissions.sh": "exglobal_prep_emissions.py",
         "exgcafs_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
         "exgcafs_atmos_products.sh": "exglobal_atmos_products.sh",
     }
     gcdas_ex_scripts = {
         "exgcdas_forecast.sh": "exglobal_forecast.sh",
-        "exgcdas_prep_emissions.py": "exglobal_prep_emissions.py",
+        "exgcdas_prep_emissions.sh": "exglobal_prep_emissions.py",
         "exgcdas_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
         "exgcdas_atmos_products.sh": "exglobal_atmos_products.sh",
         "exgcdas_atmos_initialize.py": "exglobal_offline_atmos_analysis.py",
@@ -533,28 +522,6 @@ def setup_gcafs_for_nco():
     # Next, copy ex-scripts from dev/scripts to the global workflow directory
     ex_script_file_copy_list = copy_script_files(global_workflow_dir)
 
-    # Re-extract mappings for script renaming inside jobs
-    gcafs_ex_scripts = {
-        "exgcafs_forecast.sh": "exglobal_forecast.sh",
-        "exgcafs_prep_emissions.py": "exglobal_prep_emissions.py",
-        "exgcafs_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
-        "exgcafs_atmos_products.sh": "exglobal_atmos_products.sh",
-    }
-    gcdas_ex_scripts = {
-        "exgcdas_forecast.sh": "exglobal_forecast.sh",
-        "exgcdas_prep_emissions.py": "exglobal_prep_emissions.py",
-        "exgcdas_atmos_post_manager.sh": "exglobal_atmos_pmgr.sh",
-        "exgcdas_atmos_products.sh": "exglobal_atmos_products.sh",
-        "exgcdas_atmos_initialize.py": "exglobal_offline_atmos_analysis.py",
-        "exgcdas_surface_initialize.sh": "exglobal_atmos_sfcanl.sh",
-        "exgcdas_aero_analysis_initialize.py": "exglobal_aero_analysis_initialize.py",
-        "exgcdas_aero_analysis_variational.py": "exglobal_aero_analysis_variational.py",
-        "exgcdas_aero_analysis_finalize.py": "exglobal_aero_analysis_finalize.py",
-        "exgcdas_aero_analysis_calc.sh": "exglobal_atmos_analysis_calc.sh",
-        "exgcdas_aero_analysis_stats.py": "exglobal_analysis_stats.py",
-        "exgcdas_aero_analysis_generate_bmatrix.py": "exgdas_aero_analysis_generate_bmatrix.py",
-    }
-
     # Remove unused executables from the exec directory
     removed_files = remove_unused_executables(global_workflow_dir)
 
@@ -572,20 +539,10 @@ def setup_gcafs_for_nco():
             num_tmpl_replacements = replace_declare_from_tmpl_in_file(file_path, templates)
             print(f"Replaced {num_tmpl_replacements} declare_from_tmpl calls in {file_path}")
 
-            # Specific script renaming inside jobs
+            # Ensure common variables are defined even for single member or deterministic runs
             with open(file_path, 'r') as f:
                 content = f.read()
 
-            filename = os.path.basename(file_path)
-            script_map = gcdas_ex_scripts if filename.startswith('JGCDAS_') else gcafs_ex_scripts
-            
-            # Replace script references
-            for dest_script, src_script in script_map.items():
-                if src_script in content:
-                    content = content.replace(src_script, dest_script)
-                    print(f"  Renamed {src_script} to {dest_script} in {filename}")
-
-            # Ensure common variables are defined even for single member or deterministic runs
             vars_to_define = ['MEMDIR', 'COMINgcafs', 'COMOUTgcafs']
             modified = False
             for var in vars_to_define:
@@ -598,8 +555,9 @@ def setup_gcafs_for_nco():
                         modified = True
                         print(f"Added {var} export to {file_path}")
 
-            with open(file_path, 'w') as f:
-                f.write(content)
+            if modified:
+                with open(file_path, 'w') as f:
+                    f.write(content)
 
 
 if __name__ == "__main__":

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -561,16 +561,18 @@ def setup_gcafs_for_nco():
     # Extract templates for declare_from_tmpl replacement
     templates = get_template_dict(global_workflow_dir)
 
-    # Go through the copied job and ex-script files and replace FOOgfs with FOOgcafs
+    # Go through the copied job and ex-script files and replace GFS with GCAFS
     all_copied_files = [dest for _, dest in job_file_copy_list + ex_script_file_copy_list]
     for file_path in all_copied_files:
         num_replacements = replace_gfs_with_gcafs(file_path)
-        print(f"Modified {file_path}: {num_replacements} replacements made.")
+        if num_replacements > 0:
+            print(f"Modified {file_path}: {num_replacements} replacements made.")
 
         # For job files, also replace declare_from_tmpl with explicit exports
         if '/jobs/' in file_path:
             num_tmpl_replacements = replace_declare_from_tmpl_in_file(file_path, templates)
-            print(f"Replaced {num_tmpl_replacements} declare_from_tmpl calls in {file_path}")
+            if num_tmpl_replacements > 0:
+                print(f"Replaced {num_tmpl_replacements} declare_from_tmpl calls in {file_path}")
 
             # Specific script renaming inside jobs
             with open(file_path, 'r') as f:
@@ -579,27 +581,61 @@ def setup_gcafs_for_nco():
             filename = os.path.basename(file_path)
             script_map = gcdas_ex_scripts if filename.startswith('JGCDAS_') else gcafs_ex_scripts
             
-            # Replace script references
+            # Replace script references using the map
+            modified_job = False
             for dest_script, src_script in script_map.items():
                 if src_script in content:
                     content = content.replace(src_script, dest_script)
+                    modified_job = True
                     print(f"  Renamed {src_script} to {dest_script} in {filename}")
 
-            # Ensure common variables are defined even for single member or deterministic runs
-            vars_to_define = ['MEMDIR', 'COMINgcafs', 'COMOUTgcafs']
-            modified = False
-            for var in vars_to_define:
-                if f'export {var}=' not in content:
-                    # Insert after jjob_header.sh source
-                    header_pattern = r'(source\s+.*jjob_header\.sh.*)'
-                    match = re.search(header_pattern, content)
-                    if match:
-                        content = re.sub(header_pattern, f'\\1\nexport {var}=${{{var}:-""}}', content)
-                        modified = True
-                        print(f"Added {var} export to {file_path}")
+            # Also catch any missed 'exglobal_' and replace with 'exgcafs_' or 'exgcdas_'
+            prefix = 'exgcafs_' if filename.startswith('JGCAFS_') else 'exgcdas_'
+            if re.search(r'\bexglobal_', content):
+                content = re.sub(r'\bexglobal_', prefix, content)
+                modified_job = True
 
-            with open(file_path, 'w') as f:
-                f.write(content)
+            # Ensure common variables are defined even for single member or deterministic runs
+            # Find all exported COMIN/COMOUT variables
+            exports = re.findall(r'export\s+((?:COMIN|COMOUT)\w*)=', content)
+            alias_lines = []
+            for exp in exports:
+                # If it's a gcafs/gcdas var, add a gfs alias for Python compatibility
+                # If it's a plain COMIN_VAR, add a gfs alias too
+                if 'gcafs' in exp.lower() or 'gcdas' in exp.lower() or 'gfs' not in exp.lower():
+                    gfs_alias = exp
+                    if 'gcafs' in gfs_alias.lower():
+                        gfs_alias = re.sub(r'gcafs', 'gfs', gfs_alias, flags=re.IGNORECASE)
+                    elif 'gcdas' in gfs_alias.lower():
+                        gfs_alias = re.sub(r'gcdas', 'gfs', gfs_alias, flags=re.IGNORECASE)
+                    else:
+                        # For COMIN_ATMOS_ANALYSIS -> COMINgfs_ATMOS_ANALYSIS
+                        if '_' in gfs_alias:
+                            pre, post = gfs_alias.split('_', 1)
+                            gfs_alias = f"{pre}gfs_{post}"
+                    
+                    if gfs_alias != exp and f'export {gfs_alias}=' not in content:
+                        alias_lines.append(f'export {gfs_alias}="${{{exp}}}"')
+
+            # Add required exports
+            required_vars = ['MEMDIR', 'COMINgcafs', 'COMOUTgcafs']
+            for var in required_vars:
+                if f'export {var}=' not in content:
+                    alias_lines.append(f'export {var}=${{{var}:-""}}')
+
+            if alias_lines:
+                # Insert after jjob_header.sh source
+                header_pattern = r'(source\s+.*jjob_header\.sh.*)'
+                match = re.search(header_pattern, content)
+                if match:
+                    insertion = '\n' + '\n'.join(alias_lines)
+                    content = re.sub(header_pattern, f'\\1{insertion}', content)
+                    modified_job = True
+                    print(f"  Added {len(alias_lines)} alias/required exports to {filename}")
+
+            if modified_job:
+                with open(file_path, 'w') as f:
+                    f.write(content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `setup_gcafs_for_nco.py` script has been enhanced to automate the conversion of dynamic `declare_from_tmpl` bash calls into static `export` statements. 

Key changes include:
1.  **Template Extraction:** A new `get_template_dict` function parses `dev/parm/config/gfs/config.com` (favoring the NCO conditional branch) and all other `config.*` files to collect template definitions.
2.  **Recursive Resolution:** Templates are resolved recursively (e.g., resolving `COM_BASE` within other path templates) while preserving standard global workflow variables (like `${ROTDIR}`, `${RUN}`, etc.) as per requirements.
3.  **Bash-aware Parsing:** Implemented `parse_overrides` and `resolve_template` to correctly handle bash environment overrides that often precede `declare_from_tmpl` calls (e.g., `YMD=${PDY} HH=${cyc}`).
4.  **JJOB Transformation:** The `replace_declare_from_tmpl_in_file` function uses a comprehensive regex to identify and replace these calls in all copied JJOBs, maintaining proper indentation and handling multiline syntax.

This enhancement ensures that the generated GCAFS workflow for NCO is Enterprise Environmental 2 (EE2) compliant by making path definitions explicit and reducing reliance on custom bash utility functions at runtime.

---
*PR created automatically by Jules for task [17305223296657552000](https://jules.google.com/task/17305223296657552000) started by @bbakernoaa*